### PR TITLE
Add to gitignore. Py3 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+*.egg-info/
+build/
+dist/

--- a/pim/utils.py
+++ b/pim/utils.py
@@ -35,7 +35,7 @@ def fillin(source, fields, stringify=True):
     basedir = os.path.dirname(os.path.realpath(__file__))
     with open(os.path.join(basedir, 'templates', source), 'r') as t:
         template = t.read()
-        for k, v in fields.iteritems():
+        for k, v in fields.items():
             v = tostring(v) if stringify else v
             template = template.replace('{{ ' + k + ' }}', v)
     return template


### PR DESCRIPTION
Couple of minor additions.
- `.iteritems()` i py2 only. I suppose you could use `six.iteritems` if it is important that this remains a generator, otherwise `.items()` is sufficient
- add some more setuptools stuff to gitignore
