### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include */**/*.txt
 include README.md
+include requirements.txt


### PR DESCRIPTION
This looks like an awesome project! I'm trying it out to package up some single cell papers' data as PyPI packages.

When installing `pim` via `pip`, I got this error:

```
$ pip install pim   
Collecting pim
  Downloading pim-1.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/70/9pmmxs613fg12b1kl7gkgfjm0000gn/T/pip-build-47rcwgch/pim/setup.py", line 7, in <module>
        required = open('requirements.txt').read().split('\n')
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/70/9pmmxs613fg12b1kl7gkgfjm0000gn/T/pip-build-47rcwgch/pim/
```

This usually means that `requirements.txt` wasn't sent over to PyPI during `python setup.py upload`. This PR adds `requirements.txt` to `MANIFEST.in` to make sure it's included.